### PR TITLE
Robot state fix

### DIFF
--- a/tough_common/include/tough_common/robot_state.h
+++ b/tough_common/include/tough_common/robot_state.h
@@ -88,19 +88,58 @@ private:
   }
 
 public:
+  /**
+   * @brief Get the Robot State Informer object. Use this function to access a pointer to the object of
+   * RobotStateInformer. Only one object of this class is created and it is shared with all the classes that use
+   * RobotStateInformer.
+   *
+   * @param nh ros Nodehandle
+   * @return RobotStateInformer*
+   */
   static RobotStateInformer* getRobotStateInformer(ros::NodeHandle nh);
   ~RobotStateInformer();
 
-  // disable assign and copy. This is required for singleton pattern
+  /**
+   * @brief disable copy constructor. This is required for singleton pattern
+   *
+   */
   RobotStateInformer(RobotStateInformer const&) = delete;
+  /**
+   * @brief disable assignment operator. This is required for singleton pattern
+   *
+   */
   void operator=(RobotStateInformer const&) = delete;
 
+  /**
+   * @brief Get the current joint state message
+   *
+   * @param jointState [output]
+   */
   void getJointStateMessage(sensor_msgs::JointState& jointState);
 
+  /**
+   * @brief Get the current positions of all joints. Ordering is based on joint names.
+   *
+   * @param positions [output]
+   */
   void getJointPositions(std::vector<double>& positions);
+  /**
+   * @brief Get the current positions of joint names present in the parameter
+   *
+   * @param paramName - Parameter on ros param server that has an array of joint names
+   * @param positions [output]
+   * @return true when successful
+   * @return false
+   */
   bool getJointPositions(const std::string& paramName, std::vector<double>& positions);
 
+  /**
+   * @brief Get the current velocities of joints
+   *
+   * @param velocities [output]
+   */
   void getJointVelocities(std::vector<double>& velocities);
+
   bool getJointVelocities(const std::string& paramName, std::vector<double>& velocities);
 
   void getJointEfforts(std::vector<double>& efforts);
@@ -128,6 +167,8 @@ public:
   bool transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out, const std::string& from_frame,
                       const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
+  bool transformPose(const geometry_msgs::PoseStamped& pose_in, geometry_msgs::PoseStamped& pose_out,
+                     const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
   bool transformPose(const geometry_msgs::Pose& pose_in, geometry_msgs::Pose& pose_out, const std::string& from_frame,
                      const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
   bool transformPose(const geometry_msgs::Pose2D& pose_in, geometry_msgs::Pose2D& pose_out,

--- a/tough_common/include/tough_common/robot_state.h
+++ b/tough_common/include/tough_common/robot_state.h
@@ -26,48 +26,50 @@ class RobotStateInformer
 private:
   // private constructor to disable user from creating objects
   RobotStateInformer(ros::NodeHandle nh);
-  static RobotStateInformer* currentObject_;
+  static RobotStateInformer *currentObject_;
 
-  RobotDescription* rd_;
+  RobotDescription *rd_;
 
   ros::NodeHandle nh_;
   tf::TransformListener listener_;
   std::string robotName_;
 
   ros::Subscriber jointStateSub_;
-  void jointStateCB(const sensor_msgs::JointStatePtr msg);
+  void jointStateCB(const sensor_msgs::JointStateConstPtr msg);
+  sensor_msgs::JointStateConstPtr currentStatePtr_;
   std::map<std::string, RobotState> currentState_;
   std::mutex currentStateMutex_;
 
   ros::Subscriber pelvisIMUSub_;
-  void pelvisImuCB(const sensor_msgs::Imu& msg);
-  sensor_msgs::Imu pelvisImuValue_;
+  void pelvisImuCB(const sensor_msgs::ImuConstPtr msg);
+  sensor_msgs::ImuConstPtr pelvisImuValue_;
 
   ros::Subscriber centerOfMassSub_;
-  void centerOfMassCB(const geometry_msgs::Point32& msg);
-  geometry_msgs::Point centerOfMassValue_;
+  void centerOfMassCB(const geometry_msgs::Point32ConstPtr msg);
+  geometry_msgs::Point32ConstPtr centerOfMassValue_;
 
   ros::Subscriber capturePointSub_;
-  void capturPointCB(const ihmc_msgs::Point2dRosMessage& msg);
-  geometry_msgs::Point capturePointValue_;
+  void capturPointCB(const ihmc_msgs::Point2dRosMessageConstPtr msg);
+  ihmc_msgs::Point2dRosMessageConstPtr capturePointValue_;
 
   ros::Subscriber isInDoubleSupportSub_;
-  void doubleSupportStatusCB(const std_msgs::Bool& msg);
+  void doubleSupportStatusCB(const std_msgs::Bool &msg);
   bool doubleSupportStatus_;
 
   ros::Subscriber leftFootForceSensorSub_;
   ros::Subscriber rightFootForceSensorSub_;
-  void leftFootForceSensorCB(const geometry_msgs::WrenchStamped& msg);
-  void rightFootForceSensorCB(const geometry_msgs::WrenchStamped& msg);
-  std::map<RobotSide, geometry_msgs::Wrench> footWrenches_;
+  void leftFootForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg);
+  void rightFootForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg);
+  std::map<RobotSide, geometry_msgs::WrenchStampedConstPtr> footWrenches_;
 
   ros::Subscriber leftWristForceSensorSub_;
   ros::Subscriber rightWristForceSensorSub_;
-  void leftWristForceSensorCB(const geometry_msgs::WrenchStamped& msg);
-  void rightWristForceSensorCB(const geometry_msgs::WrenchStamped& msg);
-  std::map<RobotSide, geometry_msgs::Wrench> wristWrenches_;
+  void leftWristForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg);
+  void rightWristForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg);
+  std::map<RobotSide, geometry_msgs::WrenchStampedConstPtr> wristWrenches_;
 
-  void inline parseParameter(const std::string& paramName, std::string& parameter)
+void populateStateMap();
+  void inline parseParameter(const std::string &paramName, std::string &parameter)
   {
     if (paramName == "left_arm_joint_names" || paramName == "left_arm")
     {
@@ -86,75 +88,75 @@ private:
   }
 
 public:
-  static RobotStateInformer* getRobotStateInformer(ros::NodeHandle nh);
+  static RobotStateInformer *getRobotStateInformer(ros::NodeHandle nh);
   ~RobotStateInformer();
 
   // disable assign and copy. This is required for singleton pattern
-  RobotStateInformer(RobotStateInformer const&) = delete;
-  void operator=(RobotStateInformer const&) = delete;
+  RobotStateInformer(RobotStateInformer const &) = delete;
+  void operator=(RobotStateInformer const &) = delete;
 
-  void getJointStateMessage(sensor_msgs::JointState& jointState);
+  void getJointStateMessage(sensor_msgs::JointState &jointState);
 
-  void getJointPositions(std::vector<double>& positions);
-  bool getJointPositions(const std::string& paramName, std::vector<double>& positions);
+  void getJointPositions(std::vector<double> &positions);
+  bool getJointPositions(const std::string &paramName, std::vector<double> &positions);
 
-  void getJointVelocities(std::vector<double>& velocities);
-  bool getJointVelocities(const std::string& paramName, std::vector<double>& velocities);
+  void getJointVelocities(std::vector<double> &velocities);
+  bool getJointVelocities(const std::string &paramName, std::vector<double> &velocities);
 
-  void getJointEfforts(std::vector<double>& efforts);
-  bool getJointEfforts(const std::string& paramName, std::vector<double>& efforts);
+  void getJointEfforts(std::vector<double> &efforts);
+  bool getJointEfforts(const std::string &paramName, std::vector<double> &efforts);
 
-  double getJointPosition(const std::string& jointName);
-  double getJointVelocity(const std::string& jointName);
-  double getJointEffort(const std::string& jointName);
+  double getJointPosition(const std::string &jointName);
+  double getJointVelocity(const std::string &jointName);
+  double getJointEffort(const std::string &jointName);
 
-  void getJointNames(std::vector<std::string>& jointNames);
+  void getJointNames(std::vector<std::string> &jointNames);
 
-  bool getCurrentPose(const std::string& frameName, geometry_msgs::Pose& pose,
-                      const std::string& baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool getCurrentPose(const std::string &frameName, geometry_msgs::Pose &pose,
+                      const std::string &baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool getTransform(const std::string& frameName, tf::StampedTransform& transform,
-                    const std::string& baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool getTransform(const std::string &frameName, tf::StampedTransform &transform,
+                    const std::string &baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformQuaternion(const geometry_msgs::QuaternionStamped& qt_in, geometry_msgs::QuaternionStamped& qt_out,
+  bool transformQuaternion(const geometry_msgs::QuaternionStamped &qt_in, geometry_msgs::QuaternionStamped &qt_out,
                            const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformQuaternion(const geometry_msgs::Quaternion& qt_in, geometry_msgs::Quaternion& qt_out,
-                           const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformQuaternion(const geometry_msgs::Quaternion &qt_in, geometry_msgs::Quaternion &qt_out,
+                           const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformPoint(const geometry_msgs::PointStamped& pt_in, geometry_msgs::PointStamped& pt_out,
+  bool transformPoint(const geometry_msgs::PointStamped &pt_in, geometry_msgs::PointStamped &pt_out,
                       const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out, const std::string& from_frame,
-                      const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPoint(const geometry_msgs::Point &pt_in, geometry_msgs::Point &pt_out, const std::string &from_frame,
+                      const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformPose(const geometry_msgs::Pose& pose_in, geometry_msgs::Pose& pose_out, const std::string& from_frame,
-                     const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformPose(const geometry_msgs::Pose2D& pose_in, geometry_msgs::Pose2D& pose_out,
-                     const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPose(const geometry_msgs::Pose &pose_in, geometry_msgs::Pose &pose_out, const std::string &from_frame,
+                     const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPose(const geometry_msgs::Pose2D &pose_in, geometry_msgs::Pose2D &pose_out,
+                     const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformVector(const geometry_msgs::Vector3& vec_in, geometry_msgs::Vector3& vec_out,
-                       const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformVector(const geometry_msgs::Vector3Stamped& vec_in, geometry_msgs::Vector3Stamped& vec_out,
+  bool transformVector(const geometry_msgs::Vector3 &vec_in, geometry_msgs::Vector3 &vec_out,
+                       const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformVector(const geometry_msgs::Vector3Stamped &vec_in, geometry_msgs::Vector3Stamped &vec_out,
                        const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  void getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches);
-  void getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches);
+  void getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches);
+  void getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches);
 
-  void getFootWrench(const RobotSide side, geometry_msgs::Wrench& wrench);
-  void getWristWrench(const RobotSide side, geometry_msgs::Wrench& wrench);
+  void getFootWrench(const RobotSide side, geometry_msgs::Wrench &wrench);
+  void getWristWrench(const RobotSide side, geometry_msgs::Wrench &wrench);
 
-  void getFootForce(const RobotSide side, geometry_msgs::Vector3& force);
-  void getFootTorque(const RobotSide side, geometry_msgs::Vector3& torque);
+  void getFootForce(const RobotSide side, geometry_msgs::Vector3 &force);
+  void getFootTorque(const RobotSide side, geometry_msgs::Vector3 &torque);
 
-  void getWristForce(const RobotSide side, geometry_msgs::Vector3& force);
-  void getWristTorque(const RobotSide side, geometry_msgs::Vector3& torque);
+  void getWristForce(const RobotSide side, geometry_msgs::Vector3 &force);
+  void getWristTorque(const RobotSide side, geometry_msgs::Vector3 &torque);
 
   bool isRobotInDoubleSupport();
 
-  void getCapturePoint(geometry_msgs::Point& point);
+  void getCapturePoint(geometry_msgs::Point &point);
 
-  void getCenterOfMass(geometry_msgs::Point& point);
+  void getCenterOfMass(geometry_msgs::Point &point);
 
-  void getPelvisIMUReading(sensor_msgs::Imu& msg);
+  void getPelvisIMUReading(sensor_msgs::Imu &msg);
 };
 
-#endif  // TOUGH_ROBOT_STATE_INFORMER_H
+#endif // TOUGH_ROBOT_STATE_INFORMER_H

--- a/tough_common/include/tough_common/robot_state.h
+++ b/tough_common/include/tough_common/robot_state.h
@@ -26,9 +26,9 @@ class RobotStateInformer
 private:
   // private constructor to disable user from creating objects
   RobotStateInformer(ros::NodeHandle nh);
-  static RobotStateInformer *currentObject_;
+  static RobotStateInformer* currentObject_;
 
-  RobotDescription *rd_;
+  RobotDescription* rd_;
 
   ros::NodeHandle nh_;
   tf::TransformListener listener_;
@@ -53,7 +53,7 @@ private:
   ihmc_msgs::Point2dRosMessageConstPtr capturePointValue_;
 
   ros::Subscriber isInDoubleSupportSub_;
-  void doubleSupportStatusCB(const std_msgs::Bool &msg);
+  void doubleSupportStatusCB(const std_msgs::Bool& msg);
   bool doubleSupportStatus_;
 
   ros::Subscriber leftFootForceSensorSub_;
@@ -68,8 +68,8 @@ private:
   void rightWristForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg);
   std::map<RobotSide, geometry_msgs::WrenchStampedConstPtr> wristWrenches_;
 
-void populateStateMap();
-  void inline parseParameter(const std::string &paramName, std::string &parameter)
+  void populateStateMap();
+  void inline parseParameter(const std::string& paramName, std::string& parameter)
   {
     if (paramName == "left_arm_joint_names" || paramName == "left_arm")
     {
@@ -88,75 +88,75 @@ void populateStateMap();
   }
 
 public:
-  static RobotStateInformer *getRobotStateInformer(ros::NodeHandle nh);
+  static RobotStateInformer* getRobotStateInformer(ros::NodeHandle nh);
   ~RobotStateInformer();
 
   // disable assign and copy. This is required for singleton pattern
-  RobotStateInformer(RobotStateInformer const &) = delete;
-  void operator=(RobotStateInformer const &) = delete;
+  RobotStateInformer(RobotStateInformer const&) = delete;
+  void operator=(RobotStateInformer const&) = delete;
 
-  void getJointStateMessage(sensor_msgs::JointState &jointState);
+  void getJointStateMessage(sensor_msgs::JointState& jointState);
 
-  void getJointPositions(std::vector<double> &positions);
-  bool getJointPositions(const std::string &paramName, std::vector<double> &positions);
+  void getJointPositions(std::vector<double>& positions);
+  bool getJointPositions(const std::string& paramName, std::vector<double>& positions);
 
-  void getJointVelocities(std::vector<double> &velocities);
-  bool getJointVelocities(const std::string &paramName, std::vector<double> &velocities);
+  void getJointVelocities(std::vector<double>& velocities);
+  bool getJointVelocities(const std::string& paramName, std::vector<double>& velocities);
 
-  void getJointEfforts(std::vector<double> &efforts);
-  bool getJointEfforts(const std::string &paramName, std::vector<double> &efforts);
+  void getJointEfforts(std::vector<double>& efforts);
+  bool getJointEfforts(const std::string& paramName, std::vector<double>& efforts);
 
-  double getJointPosition(const std::string &jointName);
-  double getJointVelocity(const std::string &jointName);
-  double getJointEffort(const std::string &jointName);
+  double getJointPosition(const std::string& jointName);
+  double getJointVelocity(const std::string& jointName);
+  double getJointEffort(const std::string& jointName);
 
-  void getJointNames(std::vector<std::string> &jointNames);
+  void getJointNames(std::vector<std::string>& jointNames);
 
-  bool getCurrentPose(const std::string &frameName, geometry_msgs::Pose &pose,
-                      const std::string &baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool getCurrentPose(const std::string& frameName, geometry_msgs::Pose& pose,
+                      const std::string& baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool getTransform(const std::string &frameName, tf::StampedTransform &transform,
-                    const std::string &baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool getTransform(const std::string& frameName, tf::StampedTransform& transform,
+                    const std::string& baseFrame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformQuaternion(const geometry_msgs::QuaternionStamped &qt_in, geometry_msgs::QuaternionStamped &qt_out,
+  bool transformQuaternion(const geometry_msgs::QuaternionStamped& qt_in, geometry_msgs::QuaternionStamped& qt_out,
                            const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformQuaternion(const geometry_msgs::Quaternion &qt_in, geometry_msgs::Quaternion &qt_out,
-                           const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformQuaternion(const geometry_msgs::Quaternion& qt_in, geometry_msgs::Quaternion& qt_out,
+                           const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformPoint(const geometry_msgs::PointStamped &pt_in, geometry_msgs::PointStamped &pt_out,
+  bool transformPoint(const geometry_msgs::PointStamped& pt_in, geometry_msgs::PointStamped& pt_out,
                       const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformPoint(const geometry_msgs::Point &pt_in, geometry_msgs::Point &pt_out, const std::string &from_frame,
-                      const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out, const std::string& from_frame,
+                      const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformPose(const geometry_msgs::Pose &pose_in, geometry_msgs::Pose &pose_out, const std::string &from_frame,
-                     const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformPose(const geometry_msgs::Pose2D &pose_in, geometry_msgs::Pose2D &pose_out,
-                     const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPose(const geometry_msgs::Pose& pose_in, geometry_msgs::Pose& pose_out, const std::string& from_frame,
+                     const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformPose(const geometry_msgs::Pose2D& pose_in, geometry_msgs::Pose2D& pose_out,
+                     const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  bool transformVector(const geometry_msgs::Vector3 &vec_in, geometry_msgs::Vector3 &vec_out,
-                       const std::string &from_frame, const std::string &to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
-  bool transformVector(const geometry_msgs::Vector3Stamped &vec_in, geometry_msgs::Vector3Stamped &vec_out,
+  bool transformVector(const geometry_msgs::Vector3& vec_in, geometry_msgs::Vector3& vec_out,
+                       const std::string& from_frame, const std::string& to_frame = TOUGH_COMMON_NAMES::WORLD_TF);
+  bool transformVector(const geometry_msgs::Vector3Stamped& vec_in, geometry_msgs::Vector3Stamped& vec_out,
                        const std::string target_frame = TOUGH_COMMON_NAMES::WORLD_TF);
 
-  void getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches);
-  void getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches);
+  void getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches);
+  void getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches);
 
-  void getFootWrench(const RobotSide side, geometry_msgs::Wrench &wrench);
-  void getWristWrench(const RobotSide side, geometry_msgs::Wrench &wrench);
+  void getFootWrench(const RobotSide side, geometry_msgs::Wrench& wrench);
+  void getWristWrench(const RobotSide side, geometry_msgs::Wrench& wrench);
 
-  void getFootForce(const RobotSide side, geometry_msgs::Vector3 &force);
-  void getFootTorque(const RobotSide side, geometry_msgs::Vector3 &torque);
+  void getFootForce(const RobotSide side, geometry_msgs::Vector3& force);
+  void getFootTorque(const RobotSide side, geometry_msgs::Vector3& torque);
 
-  void getWristForce(const RobotSide side, geometry_msgs::Vector3 &force);
-  void getWristTorque(const RobotSide side, geometry_msgs::Vector3 &torque);
+  void getWristForce(const RobotSide side, geometry_msgs::Vector3& force);
+  void getWristTorque(const RobotSide side, geometry_msgs::Vector3& torque);
 
   bool isRobotInDoubleSupport();
 
-  void getCapturePoint(geometry_msgs::Point &point);
+  void getCapturePoint(geometry_msgs::Point& point);
 
-  void getCenterOfMass(geometry_msgs::Point &point);
+  void getCenterOfMass(geometry_msgs::Point& point);
 
-  void getPelvisIMUReading(sensor_msgs::Imu &msg);
+  void getPelvisIMUReading(sensor_msgs::Imu& msg);
 };
 
-#endif // TOUGH_ROBOT_STATE_INFORMER_H
+#endif  // TOUGH_ROBOT_STATE_INFORMER_H

--- a/tough_common/src/robot_state.cpp
+++ b/tough_common/src/robot_state.cpp
@@ -18,51 +18,48 @@ RobotStateInformer* RobotStateInformer::getRobotStateInformer(ros::NodeHandle nh
 RobotStateInformer::RobotStateInformer(ros::NodeHandle nh) : nh_(nh)
 {
   rd_ = RobotDescription::getRobotDescription(nh_);
-  nh.getParam(ROBOT_NAME_PARAM, robotName_);
 
+  nh.getParam(ROBOT_NAME_PARAM, robotName_);
   std::string prefix = TOPIC_PREFIX + robotName_ + OUTPUT_TOPIC_PREFIX;
 
   jointStateSub_ = nh_.subscribe(prefix + JOINT_STATES_TOPIC, 1, &RobotStateInformer::jointStateCB, this);
+
   pelvisIMUSub_ = nh_.subscribe(prefix + PELVIS_IMU_TOPIC, 1, &RobotStateInformer::pelvisImuCB, this);
   centerOfMassSub_ = nh_.subscribe(prefix + CENTER_OF_MASS_TOPIC, 1, &RobotStateInformer::centerOfMassCB, this);
   capturePointSub_ = nh_.subscribe(prefix + CAPTURE_POINT_TOPIC, 1, &RobotStateInformer::capturPointCB, this);
   isInDoubleSupportSub_ =
       nh_.subscribe(prefix + DOUBLE_SUPPORT_STATUS_TOPIC, 1, &RobotStateInformer::doubleSupportStatusCB, this);
+
   leftFootForceSensorSub_ =
       nh_.subscribe(prefix + LEFT_FOOT_FORCE_SENSOR_TOPIC, 1, &RobotStateInformer::leftFootForceSensorCB, this);
   rightFootForceSensorSub_ =
       nh_.subscribe(prefix + RIGHT_FOOT_FORCE_SENSOR_TOPIC, 1, &RobotStateInformer::rightFootForceSensorCB, this);
+
   leftWristForceSensorSub_ =
       nh_.subscribe(prefix + LEFT_WRIST_FORCE_SENSOR_TOPIC, 1, &RobotStateInformer::leftWristForceSensorCB, this);
   rightWristForceSensorSub_ =
       nh_.subscribe(prefix + RIGHT_WRIST_FORCE_SENSOR_TOPIC, 1, &RobotStateInformer::rightWristForceSensorCB, this);
-
+  ros::spinOnce();
   ros::Duration(0.2).sleep();
 }
 
 RobotStateInformer::~RobotStateInformer()
 {
   jointStateSub_.shutdown();
-}
-
-void RobotStateInformer::getJointStateMessage(sensor_msgs::JointState& jointState)
-{
-  jointState = *currentStatePtr_;
+  pelvisIMUSub_.shutdown();
+  centerOfMassSub_.shutdown();
+  capturePointSub_.shutdown();
+  isInDoubleSupportSub_.shutdown();
+  leftFootForceSensorSub_.shutdown();
+  rightFootForceSensorSub_.shutdown();
+  leftWristForceSensorSub_.shutdown();
+  rightWristForceSensorSub_.shutdown();
 }
 
 void RobotStateInformer::jointStateCB(const sensor_msgs::JointStateConstPtr msg)
 {
-  currentStatePtr_ = msg;
   std::lock_guard<std::mutex> guard(currentStateMutex_);
-  for (size_t i = 0; i < msg->name.size(); ++i)
-  {
-    RobotState state;
-    state.name = msg->name[i];
-    state.position = msg->position[i];
-    state.velocity = msg->velocity[i];
-    state.effort = msg->effort[i];
-    currentState_[msg->name[i]] = state;
-  }
+  currentStatePtr_ = msg;
 }
 
 void RobotStateInformer::pelvisImuCB(const sensor_msgs::ImuConstPtr msg)
@@ -97,6 +94,16 @@ void RobotStateInformer::leftWristForceSensorCB(const geometry_msgs::WrenchStamp
 void RobotStateInformer::rightWristForceSensorCB(const geometry_msgs::WrenchStampedConstPtr msg)
 {
   wristWrenches_[RIGHT] = msg;
+}
+
+void RobotStateInformer::getJointStateMessage(sensor_msgs::JointState& jointState)
+{
+  if (!currentStatePtr_)
+  {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(currentStateMutex_);
+  jointState = *currentStatePtr_;
 }
 
 void RobotStateInformer::getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches)
@@ -175,11 +182,20 @@ void RobotStateInformer::populateStateMap()
 }
 void RobotStateInformer::getJointPositions(std::vector<double>& positions)
 {
+  if (!currentStatePtr_)
+  {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(currentStateMutex_);
   positions = currentStatePtr_->position;
 }
 
 bool RobotStateInformer::getJointPositions(const std::string& paramName, std::vector<double>& positions)
 {
+  if (!currentStatePtr_)
+  {
+    return false;
+  }
   positions.clear();
   std::vector<std::string> jointNames;
   std::string parameter;
@@ -200,11 +216,20 @@ bool RobotStateInformer::getJointPositions(const std::string& paramName, std::ve
 
 void RobotStateInformer::getJointVelocities(std::vector<double>& velocities)
 {
+  if (!currentStatePtr_)
+  {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(currentStateMutex_);
   velocities = currentStatePtr_->velocity;
 }
 
 bool RobotStateInformer::getJointVelocities(const std::string& paramName, std::vector<double>& velocities)
 {
+  if (!currentStatePtr_)
+  {
+    return false;
+  }
   velocities.clear();
   std::vector<std::string> jointNames;
   std::string parameter;
@@ -225,11 +250,20 @@ bool RobotStateInformer::getJointVelocities(const std::string& paramName, std::v
 
 void RobotStateInformer::getJointEfforts(std::vector<double>& efforts)
 {
+  if (!currentStatePtr_)
+  {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(currentStateMutex_);
   efforts = currentStatePtr_->effort;
 }
 
 bool RobotStateInformer::getJointEfforts(const std::string& paramName, std::vector<double>& efforts)
 {
+  if (!currentStatePtr_)
+  {
+    return false;
+  }
   efforts.clear();
   std::vector<std::string> jointNames;
   std::string parameter;
@@ -286,6 +320,11 @@ double RobotStateInformer::getJointEffort(const std::string& jointName)
 
 void RobotStateInformer::getJointNames(std::vector<std::string>& jointNames)
 {
+  if (!currentStatePtr_)
+  {
+    return;
+  }
+  std::lock_guard<std::mutex> guard(currentStateMutex_);
   jointNames = currentStatePtr_->name;
 }
 
@@ -293,23 +332,16 @@ bool RobotStateInformer::getCurrentPose(const std::string& frameName, geometry_m
                                         const std::string& baseFrame)
 {
   tf::StampedTransform origin;
-
-  try
+  if (getTransform(frameName, origin, baseFrame))
   {
-    listener_.waitForTransform(baseFrame, frameName, ros::Time(0), ros::Duration(2));
-    listener_.lookupTransform(baseFrame, frameName, ros::Time(0), origin);
+    tf::pointTFToMsg(origin.getOrigin(), pose.position);
+    tf::quaternionTFToMsg(origin.getRotation(), pose.orientation);
+    return true;
   }
-  catch (tf::TransformException ex)
+  else
   {
-    ROS_WARN("%s", ex.what());
-    ros::spinOnce();
-    return false;
+    false;
   }
-
-  tf::pointTFToMsg(origin.getOrigin(), pose.position);
-  tf::quaternionTFToMsg(origin.getRotation(), pose.orientation);
-
-  return true;
 }
 
 bool RobotStateInformer::getTransform(const std::string& frameName, tf::StampedTransform& transform,
@@ -334,7 +366,7 @@ bool RobotStateInformer::transformQuaternion(const geometry_msgs::QuaternionStam
 {
   try
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
+    listener_.waitForTransform(qt_in.header.frame_id, target_frame, ros::Time(0), ros::Duration(2));
     listener_.transformQuaternion(target_frame, qt_in, qt_out);
   }
   catch (tf::TransformException ex)
@@ -352,19 +384,12 @@ bool RobotStateInformer::transformQuaternion(const geometry_msgs::Quaternion& qt
   geometry_msgs::QuaternionStamped in, out;
   in.quaternion = qt_in;
   in.header.frame_id = from_frame;
-  try
+  if (transformQuaternion(in, out, to_frame))
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
-    listener_.transformQuaternion(to_frame, in, out);
+    qt_out = out.quaternion;
+    return true;
   }
-  catch (tf::TransformException ex)
-  {
-    ROS_WARN("%s", ex.what());
-    ros::spinOnce();
-    return false;
-  }
-  qt_out = out.quaternion;
-  return true;
+  return false;
 }
 
 bool RobotStateInformer::transformPoint(const geometry_msgs::PointStamped& pt_in, geometry_msgs::PointStamped& pt_out,
@@ -372,8 +397,39 @@ bool RobotStateInformer::transformPoint(const geometry_msgs::PointStamped& pt_in
 {
   try
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
+    listener_.waitForTransform(pt_in.header.frame_id, target_frame, ros::Time(0), ros::Duration(2));
     listener_.transformPoint(target_frame, pt_in, pt_out);
+  }
+  catch (tf::TransformException ex)
+  {
+    ROS_WARN("%s", ex.what());
+    ros::spinOnce();
+    return false;
+  }
+  return true;
+}
+
+bool RobotStateInformer::transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out,
+                                        const std::string& from_frame, const std::string& to_frame)
+{
+  geometry_msgs::PointStamped in, out;
+  in.point = pt_in;
+  in.header.frame_id = from_frame;
+  if (transformPoint(in, out, to_frame))
+  {
+    pt_out = out.point;
+    return true;
+  }
+  return false;
+}
+
+bool RobotStateInformer::transformPose(const geometry_msgs::PoseStamped& pose_in, geometry_msgs::PoseStamped& pose_out,
+                                       const std::string& to_frame)
+{
+  try
+  {
+    listener_.waitForTransform(pose_in.header.frame_id, to_frame, ros::Time(0), ros::Duration(2));
+    listener_.transformPose(to_frame, pose_in, pose_out);
   }
   catch (tf::TransformException ex)
   {
@@ -391,20 +447,12 @@ bool RobotStateInformer::transformPose(const geometry_msgs::Pose& pose_in, geome
   in.header.frame_id = from_frame;
   in.header.stamp = ros::Time(0);
   in.pose = pose_in;
-  try
+  if (transformPose(pose_in, pose_out, to_frame))
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
-    listener_.transformPose(to_frame, in, out);
+    pose_out = out.pose;
+    return true;
   }
-  catch (tf::TransformException ex)
-  {
-    ROS_WARN("%s", ex.what());
-    ros::spinOnce();
-    return false;
-  }
-
-  pose_out = out.pose;
-  return true;
+  return false;
 }
 
 bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D& pose_in, geometry_msgs::Pose2D& pose_out,
@@ -420,7 +468,7 @@ bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D& pose_in, geo
 
   try
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
+    listener_.waitForTransform(from_frame, to_frame, ros::Time(0), ros::Duration(2));
     listener_.transformPose(to_frame, in, out);
   }
   catch (tf::TransformException ex)
@@ -437,34 +485,12 @@ bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D& pose_in, geo
   return true;
 }
 
-bool RobotStateInformer::transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out,
-                                        const std::string& from_frame, const std::string& to_frame)
-{
-  geometry_msgs::PointStamped stmp_pt_in, stmp_pt_out;
-  stmp_pt_in.header.frame_id = from_frame;
-  stmp_pt_in.point = pt_in;
-
-  try
-  {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
-    listener_.transformPoint(to_frame, stmp_pt_in, stmp_pt_out);
-  }
-  catch (tf::TransformException ex)
-  {
-    ROS_WARN("%s", ex.what());
-    ros::spinOnce();
-    return false;
-  }
-  pt_out = stmp_pt_out.point;
-  return true;
-}
-
 bool RobotStateInformer::transformVector(const geometry_msgs::Vector3Stamped& vec_in,
                                          geometry_msgs::Vector3Stamped& vec_out, const std::string target_frame)
 {
   try
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
+    listener_.waitForTransform(vec_in.header.frame_id, target_frame, ros::Time(0), ros::Duration(2));
     listener_.transformVector(target_frame, vec_in, vec_out);
   }
   catch (tf::TransformException ex)
@@ -482,17 +508,10 @@ bool RobotStateInformer::transformVector(const geometry_msgs::Vector3& vec_in, g
   geometry_msgs::Vector3Stamped in, out;
   in.vector = vec_in;
   in.header.frame_id = from_frame;
-  try
+  if (transformVector(in, out, to_frame))
   {
-    listener_.waitForTransform(rd_->getPelvisFrame(), rd_->getWorldFrame(), ros::Time(0), ros::Duration(2));
-    listener_.transformVector(to_frame, in, out);
+    vec_out = out.vector;
+    return true;
   }
-  catch (tf::TransformException ex)
-  {
-    ROS_WARN("%s", ex.what());
-    ros::spinOnce();
-    return false;
-  }
-  vec_out = out.vector;
-  return true;
+  return false;
 }

--- a/tough_common/src/robot_state.cpp
+++ b/tough_common/src/robot_state.cpp
@@ -1,10 +1,10 @@
 #include "tough_common/robot_state.h"
 
 using namespace TOUGH_COMMON_NAMES;
-RobotStateInformer *RobotStateInformer::currentObject_ = nullptr;
+RobotStateInformer* RobotStateInformer::currentObject_ = nullptr;
 
 /* Singleton implementation */
-RobotStateInformer *RobotStateInformer::getRobotStateInformer(ros::NodeHandle nh)
+RobotStateInformer* RobotStateInformer::getRobotStateInformer(ros::NodeHandle nh)
 {
   // check if an object of this class already exists, if not create one
   if (RobotStateInformer::currentObject_ == nullptr)
@@ -45,7 +45,7 @@ RobotStateInformer::~RobotStateInformer()
   jointStateSub_.shutdown();
 }
 
-void RobotStateInformer::getJointStateMessage(sensor_msgs::JointState &jointState)
+void RobotStateInformer::getJointStateMessage(sensor_msgs::JointState& jointState)
 {
   jointState = *currentStatePtr_;
 }
@@ -78,7 +78,7 @@ void RobotStateInformer::capturPointCB(const ihmc_msgs::Point2dRosMessageConstPt
   capturePointValue_ = msg;
 }
 
-void RobotStateInformer::doubleSupportStatusCB(const std_msgs::Bool &msg)
+void RobotStateInformer::doubleSupportStatusCB(const std_msgs::Bool& msg)
 {
   doubleSupportStatus_ = msg.data;
 }
@@ -99,40 +99,40 @@ void RobotStateInformer::rightWristForceSensorCB(const geometry_msgs::WrenchStam
   wristWrenches_[RIGHT] = msg;
 }
 
-void RobotStateInformer::getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches)
+void RobotStateInformer::getFootWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches)
 {
   wrenches[LEFT] = footWrenches_[LEFT]->wrench;
   wrenches[RIGHT] = footWrenches_[RIGHT]->wrench;
 }
-void RobotStateInformer::getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench> &wrenches)
+void RobotStateInformer::getWristWrenches(std::map<RobotSide, geometry_msgs::Wrench>& wrenches)
 {
   wrenches[LEFT] = wristWrenches_[LEFT]->wrench;
   wrenches[RIGHT] = wristWrenches_[RIGHT]->wrench;
 }
 
-void RobotStateInformer::getFootWrench(const RobotSide side, geometry_msgs::Wrench &wrench)
+void RobotStateInformer::getFootWrench(const RobotSide side, geometry_msgs::Wrench& wrench)
 {
   wrench = footWrenches_[side]->wrench;
 }
-void RobotStateInformer::getWristWrench(const RobotSide side, geometry_msgs::Wrench &wrench)
+void RobotStateInformer::getWristWrench(const RobotSide side, geometry_msgs::Wrench& wrench)
 {
   wrench = wristWrenches_[side]->wrench;
 }
 
-void RobotStateInformer::getFootForce(const RobotSide side, geometry_msgs::Vector3 &force)
+void RobotStateInformer::getFootForce(const RobotSide side, geometry_msgs::Vector3& force)
 {
   force = footWrenches_[side]->wrench.force;
 }
-void RobotStateInformer::getFootTorque(const RobotSide side, geometry_msgs::Vector3 &torque)
+void RobotStateInformer::getFootTorque(const RobotSide side, geometry_msgs::Vector3& torque)
 {
   torque = footWrenches_[side]->wrench.torque;
 }
 
-void RobotStateInformer::getWristForce(const RobotSide side, geometry_msgs::Vector3 &force)
+void RobotStateInformer::getWristForce(const RobotSide side, geometry_msgs::Vector3& force)
 {
   force = wristWrenches_[side]->wrench.force;
 }
-void RobotStateInformer::getWristTorque(const RobotSide side, geometry_msgs::Vector3 &torque)
+void RobotStateInformer::getWristTorque(const RobotSide side, geometry_msgs::Vector3& torque)
 {
   torque = wristWrenches_[side]->wrench.torque;
 }
@@ -142,21 +142,21 @@ bool RobotStateInformer::isRobotInDoubleSupport()
   return doubleSupportStatus_;
 }
 
-void RobotStateInformer::getCapturePoint(geometry_msgs::Point &point)
+void RobotStateInformer::getCapturePoint(geometry_msgs::Point& point)
 {
   point.x = capturePointValue_->x;
   point.y = capturePointValue_->y;
   point.z = 0.0;
 }
 
-void RobotStateInformer::getCenterOfMass(geometry_msgs::Point &point)
+void RobotStateInformer::getCenterOfMass(geometry_msgs::Point& point)
 {
   point.x = centerOfMassValue_->x;
   point.y = centerOfMassValue_->y;
   point.z = centerOfMassValue_->z;
 }
 
-void RobotStateInformer::getPelvisIMUReading(sensor_msgs::Imu &msg)
+void RobotStateInformer::getPelvisIMUReading(sensor_msgs::Imu& msg)
 {
   msg = *pelvisImuValue_;
 }
@@ -173,12 +173,12 @@ void RobotStateInformer::populateStateMap()
     currentState_[currentStatePtr_->name[i]] = state;
   }
 }
-void RobotStateInformer::getJointPositions(std::vector<double> &positions)
+void RobotStateInformer::getJointPositions(std::vector<double>& positions)
 {
   positions = currentStatePtr_->position;
 }
 
-bool RobotStateInformer::getJointPositions(const std::string &paramName, std::vector<double> &positions)
+bool RobotStateInformer::getJointPositions(const std::string& paramName, std::vector<double>& positions)
 {
   positions.clear();
   std::vector<std::string> jointNames;
@@ -198,12 +198,12 @@ bool RobotStateInformer::getJointPositions(const std::string &paramName, std::ve
   return false;
 }
 
-void RobotStateInformer::getJointVelocities(std::vector<double> &velocities)
+void RobotStateInformer::getJointVelocities(std::vector<double>& velocities)
 {
   velocities = currentStatePtr_->velocity;
 }
 
-bool RobotStateInformer::getJointVelocities(const std::string &paramName, std::vector<double> &velocities)
+bool RobotStateInformer::getJointVelocities(const std::string& paramName, std::vector<double>& velocities)
 {
   velocities.clear();
   std::vector<std::string> jointNames;
@@ -223,12 +223,12 @@ bool RobotStateInformer::getJointVelocities(const std::string &paramName, std::v
   return false;
 }
 
-void RobotStateInformer::getJointEfforts(std::vector<double> &efforts)
+void RobotStateInformer::getJointEfforts(std::vector<double>& efforts)
 {
   efforts = currentStatePtr_->effort;
 }
 
-bool RobotStateInformer::getJointEfforts(const std::string &paramName, std::vector<double> &efforts)
+bool RobotStateInformer::getJointEfforts(const std::string& paramName, std::vector<double>& efforts)
 {
   efforts.clear();
   std::vector<std::string> jointNames;
@@ -248,7 +248,7 @@ bool RobotStateInformer::getJointEfforts(const std::string &paramName, std::vect
   return false;
 }
 
-double RobotStateInformer::getJointPosition(const std::string &jointName)
+double RobotStateInformer::getJointPosition(const std::string& jointName)
 {
   std::lock_guard<std::mutex> guard(currentStateMutex_);
   for (int i = 0; i < currentStatePtr_->name.size(); i++)
@@ -260,7 +260,7 @@ double RobotStateInformer::getJointPosition(const std::string &jointName)
   }
 }
 
-double RobotStateInformer::getJointVelocity(const std::string &jointName)
+double RobotStateInformer::getJointVelocity(const std::string& jointName)
 {
   std::lock_guard<std::mutex> guard(currentStateMutex_);
   for (int i = 0; i < currentStatePtr_->name.size(); i++)
@@ -272,7 +272,7 @@ double RobotStateInformer::getJointVelocity(const std::string &jointName)
   }
 }
 
-double RobotStateInformer::getJointEffort(const std::string &jointName)
+double RobotStateInformer::getJointEffort(const std::string& jointName)
 {
   std::lock_guard<std::mutex> guard(currentStateMutex_);
   for (int i = 0; i < currentStatePtr_->name.size(); i++)
@@ -284,13 +284,13 @@ double RobotStateInformer::getJointEffort(const std::string &jointName)
   }
 }
 
-void RobotStateInformer::getJointNames(std::vector<std::string> &jointNames)
+void RobotStateInformer::getJointNames(std::vector<std::string>& jointNames)
 {
   jointNames = currentStatePtr_->name;
 }
 
-bool RobotStateInformer::getCurrentPose(const std::string &frameName, geometry_msgs::Pose &pose,
-                                        const std::string &baseFrame)
+bool RobotStateInformer::getCurrentPose(const std::string& frameName, geometry_msgs::Pose& pose,
+                                        const std::string& baseFrame)
 {
   tf::StampedTransform origin;
 
@@ -312,8 +312,8 @@ bool RobotStateInformer::getCurrentPose(const std::string &frameName, geometry_m
   return true;
 }
 
-bool RobotStateInformer::getTransform(const std::string &frameName, tf::StampedTransform &transform,
-                                      const std::string &baseFrame)
+bool RobotStateInformer::getTransform(const std::string& frameName, tf::StampedTransform& transform,
+                                      const std::string& baseFrame)
 {
   try
   {
@@ -329,8 +329,8 @@ bool RobotStateInformer::getTransform(const std::string &frameName, tf::StampedT
   return true;
 }
 
-bool RobotStateInformer::transformQuaternion(const geometry_msgs::QuaternionStamped &qt_in,
-                                             geometry_msgs::QuaternionStamped &qt_out, const std::string target_frame)
+bool RobotStateInformer::transformQuaternion(const geometry_msgs::QuaternionStamped& qt_in,
+                                             geometry_msgs::QuaternionStamped& qt_out, const std::string target_frame)
 {
   try
   {
@@ -346,8 +346,8 @@ bool RobotStateInformer::transformQuaternion(const geometry_msgs::QuaternionStam
   return true;
 }
 
-bool RobotStateInformer::transformQuaternion(const geometry_msgs::Quaternion &qt_in, geometry_msgs::Quaternion &qt_out,
-                                             const std::string &from_frame, const std::string &to_frame)
+bool RobotStateInformer::transformQuaternion(const geometry_msgs::Quaternion& qt_in, geometry_msgs::Quaternion& qt_out,
+                                             const std::string& from_frame, const std::string& to_frame)
 {
   geometry_msgs::QuaternionStamped in, out;
   in.quaternion = qt_in;
@@ -367,7 +367,7 @@ bool RobotStateInformer::transformQuaternion(const geometry_msgs::Quaternion &qt
   return true;
 }
 
-bool RobotStateInformer::transformPoint(const geometry_msgs::PointStamped &pt_in, geometry_msgs::PointStamped &pt_out,
+bool RobotStateInformer::transformPoint(const geometry_msgs::PointStamped& pt_in, geometry_msgs::PointStamped& pt_out,
                                         const std::string target_frame)
 {
   try
@@ -384,8 +384,8 @@ bool RobotStateInformer::transformPoint(const geometry_msgs::PointStamped &pt_in
   return true;
 }
 
-bool RobotStateInformer::transformPose(const geometry_msgs::Pose &pose_in, geometry_msgs::Pose &pose_out,
-                                       const std::string &from_frame, const std::string &to_frame)
+bool RobotStateInformer::transformPose(const geometry_msgs::Pose& pose_in, geometry_msgs::Pose& pose_out,
+                                       const std::string& from_frame, const std::string& to_frame)
 {
   geometry_msgs::PoseStamped in, out;
   in.header.frame_id = from_frame;
@@ -407,8 +407,8 @@ bool RobotStateInformer::transformPose(const geometry_msgs::Pose &pose_in, geome
   return true;
 }
 
-bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D &pose_in, geometry_msgs::Pose2D &pose_out,
-                                       const std::string &from_frame, const std::string &to_frame)
+bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D& pose_in, geometry_msgs::Pose2D& pose_out,
+                                       const std::string& from_frame, const std::string& to_frame)
 {
   geometry_msgs::PoseStamped in, out;
   in.header.frame_id = from_frame;
@@ -437,8 +437,8 @@ bool RobotStateInformer::transformPose(const geometry_msgs::Pose2D &pose_in, geo
   return true;
 }
 
-bool RobotStateInformer::transformPoint(const geometry_msgs::Point &pt_in, geometry_msgs::Point &pt_out,
-                                        const std::string &from_frame, const std::string &to_frame)
+bool RobotStateInformer::transformPoint(const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out,
+                                        const std::string& from_frame, const std::string& to_frame)
 {
   geometry_msgs::PointStamped stmp_pt_in, stmp_pt_out;
   stmp_pt_in.header.frame_id = from_frame;
@@ -459,8 +459,8 @@ bool RobotStateInformer::transformPoint(const geometry_msgs::Point &pt_in, geome
   return true;
 }
 
-bool RobotStateInformer::transformVector(const geometry_msgs::Vector3Stamped &vec_in,
-                                         geometry_msgs::Vector3Stamped &vec_out, const std::string target_frame)
+bool RobotStateInformer::transformVector(const geometry_msgs::Vector3Stamped& vec_in,
+                                         geometry_msgs::Vector3Stamped& vec_out, const std::string target_frame)
 {
   try
   {
@@ -476,8 +476,8 @@ bool RobotStateInformer::transformVector(const geometry_msgs::Vector3Stamped &ve
   return true;
 }
 
-bool RobotStateInformer::transformVector(const geometry_msgs::Vector3 &vec_in, geometry_msgs::Vector3 &vec_out,
-                                         const std::string &from_frame, const std::string &to_frame)
+bool RobotStateInformer::transformVector(const geometry_msgs::Vector3& vec_in, geometry_msgs::Vector3& vec_out,
+                                         const std::string& from_frame, const std::string& to_frame)
 {
   geometry_msgs::Vector3Stamped in, out;
   in.vector = vec_in;

--- a/tough_common/src/test_robot_state.cpp
+++ b/tough_common/src/test_robot_state.cpp
@@ -19,9 +19,19 @@ int main(int argc, char** argv)
     totalEffort += fabs(i);
   }
   std::cout << "Total Effort : " << totalEffort << std::endl;
-  ros::Duration(2).sleep();
-  ros::spinOnce();
-  // loop.sleep();
+
+  ros::Rate loopRate(10);
+
+  std::map<RobotSide, geometry_msgs::Wrench> wrenches;
+  while (ros::ok())
+  {
+    ROS_INFO("Double support : %s", obj->isRobotInDoubleSupport() ? "True" : "False");
+
+    obj->getFootWrenches(wrenches);
+
+    ROS_INFO("Foot force on left leg in z axis %.2f", wrenches[LEFT].force.z);
+    loopRate.sleep();
+  }
 
   return 0;
 }


### PR DESCRIPTION
Modified robot state to not populate class variables in every callback, instead the message from callback is copied directly when a user requests for data. about 3 functions are less efficient now, but overall efficiency should be far better.

Needs a thorough review!